### PR TITLE
Add HTTP security headers to requests using helmet

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "gulp-uglify": "^1.0.2",
     "gulp-watch": "^3.0.0",
     "habitat": "^3.1.2",
+    "helmet": " ^1.1.0",
     "jshint-jsx": "^0.4.0",
     "live-server": "^0.6.3",
     "lodash": "^3.10.1",

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ var compress = require('compression');
 var bodyParser = require('body-parser');
 var logger = require('morgan');
 var errorHandler = require('errorhandler');
+var helmet = require('helmet');
 
 var sessions = require('client-sessions');
 var flash = require('express-flash');
@@ -52,6 +53,7 @@ app.set('host', process.env.HOST || "http://localhost");
 app.set('github_org', 'MozillaFoundation');
 app.set('github_repo', 'plan');
 
+app.use(helmet());
 app.use(sessions({
   cookieName: 'session',
   secret: secrets.sessionSecret,


### PR DESCRIPTION
This commit adds the helmet middleware, which applies a set of security headers on requests.
